### PR TITLE
Remove broken husky pre-commit hook

### DIFF
--- a/libs/backend/.husky/pre-commit
+++ b/libs/backend/.husky/pre-commit
@@ -1,1 +1,0 @@
-pnpm exec lint-staged

--- a/libs/backend/package.json
+++ b/libs/backend/package.json
@@ -8,7 +8,6 @@
 		"dev": "tsx watch src/index.ts",
 		"build": "pkgroll",
 		"start": "tsx src/index.ts",
-		"prepare": "husky",
 		"lint": "npx eslint .",
 		"lint:fix": "npm run lint -- --fix",
 		"prettier": "npx prettier . --check",


### PR DESCRIPTION
Feel free to add it back in a way that's not broken but currently this just causes this error to be logged in the console when running `pnpm install`
```
libs/backend prepare$ husky
│ .git can't be found
└─ Done in 40ms
```