### PR TITLE
redirect when game room id is present in url

### DIFF
--- a/libs/backend/src/types/games.ts
+++ b/libs/backend/src/types/games.ts
@@ -3,4 +3,4 @@ import { GameUserInfo } from "types";
 export type Username = string;
 export type GameId = string;
 export type OpenGame = { [key: Username]: GameUserInfo };
-export type OpenGames = { [key: GameId]: OpenGame };
+export type OpenGames = { [key: GameId]: OpenGame | null };

--- a/libs/backend/src/websocket/waiting-room/join-game.ts
+++ b/libs/backend/src/websocket/waiting-room/join-game.ts
@@ -21,6 +21,14 @@ export function joinGame({
 }) {
 	const game = games[gameId];
 
+	if (!game) {
+		return updatePlayer({
+			socket,
+			event: GameEventEnum.NONEXISTENT_GAME,
+			message: "trying to join a game that either doesn't exist or is already on-going"
+		});
+	}
+
 	// when a user tries to join the same game multiple times, possibly through a different tab
 	if (game[username]) {
 		return updatePlayer({
@@ -31,11 +39,9 @@ export function joinGame({
 	}
 
 	// add a user to the game
-	if (game) {
-		game[username] = { joinedAt: new Date(), socket, userId, username };
+	game[username] = { joinedAt: new Date(), socket, userId, username };
 
-		// notify people someone joined
-		updatePlayer({ socket, event, message: gameId });
-		updatePlayersInGame({ game });
-	}
+	// notify people someone joined
+	updatePlayer({ socket, event, message: gameId });
+	updatePlayersInGame({ game });
 }

--- a/libs/backend/src/websocket/waiting-room/remove-empty-games.ts
+++ b/libs/backend/src/websocket/waiting-room/remove-empty-games.ts
@@ -3,7 +3,7 @@ import { removeGameFromGames } from "./remove-game-from-games.js";
 
 export async function removeEmptyGames({ games }: { games: OpenGames }) {
 	Object.entries(games).filter(([gameId, openGame]) => {
-		if (Object.keys(openGame).length <= 0) {
+		if (!openGame || Object.keys(openGame).length <= 0) {
 			removeGameFromGames({ gameId, games });
 		}
 	});

--- a/libs/backend/src/websocket/waiting-room/remove-player-from-games.ts
+++ b/libs/backend/src/websocket/waiting-room/remove-player-from-games.ts
@@ -6,10 +6,12 @@ export async function removeStoppedPlayersFromGames({ games }: { games: OpenGame
 	// TODO: is it safe to stop when you have removed only one item, who is to say someone may join multiple through an unofficial client?
 	// looking at you :susge:
 	Object.values(games).forEach((game) => {
-		Object.values(game).filter((gameUserObj: GameUserInfo) => {
-			if (!gameUserObj.socket || gameUserObj.socket.CLOSED) {
-				removePlayerFromGame({ game, usernamePlayerToRemove: gameUserObj.username });
-			}
-		});
+		if (game) {
+			Object.values(game).filter((gameUserObj: GameUserInfo) => {
+				if (!gameUserObj.socket || gameUserObj.socket.CLOSED) {
+					removePlayerFromGame({ game, usernamePlayerToRemove: gameUserObj.username });
+				}
+			});
+		}
 	});
 }

--- a/libs/backend/src/websocket/waiting-room/update-players.ts
+++ b/libs/backend/src/websocket/waiting-room/update-players.ts
@@ -2,10 +2,16 @@ import { OpenGames } from "@/types/games.js";
 import { WebSocket } from "@fastify/websocket";
 import { updatePlayer } from "../common/update-player.js";
 import { GameEventEnum } from "types";
+import { removeGameFromGames } from "./remove-game-from-games.js";
 
 export function updatePlayers({ sockets, games }: { sockets: WebSocket[]; games: OpenGames }) {
-	const joinableGames = Object.entries(games).map(([key, value]) => {
-		return { id: key, amountOfPlayersJoined: Object.keys(value).length };
+	const joinableGames = Object.entries(games).map(([key, game]) => {
+		if (!game) {
+			removeGameFromGames({ gameId: key, games });
+			return { id: key, amountOfPlayersJoined: 0 };
+		}
+
+		return { id: key, amountOfPlayersJoined: Object.keys(game).length };
 	});
 
 	for (const socket of sockets) {


### PR DESCRIPTION
# Description

When a roomId is present in the url, the `/multiplayer` will first try to join the game if it is found, and otherwise it redirects to `/multiplayer/:id` since the game is possibly on-going but they might want to join

feat: https://github.com/JuiceMitApfelnDrin/CodinCod/issues/20

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
<!-- hard to understand area's should hardly ever exist, if they do it warrants at least an explanation in the description of the PR -->
- [x] I have made corresponding changes to the documentation
