### PR TITLE
Add sleep for better feedback

### DIFF
--- a/libs/frontend/src/lib/components/ui/avatar/avatar-fallback.svelte
+++ b/libs/frontend/src/lib/components/ui/avatar/avatar-fallback.svelte
@@ -9,7 +9,7 @@
 </script>
 
 <AvatarPrimitive.Fallback
-	class={cn("bg-muted flex h-full w-full items-center justify-center rounded-full", className)}
+	class={cn("flex h-full w-full items-center justify-center rounded-full bg-muted", className)}
 	{...$$restProps}
 >
 	<!-- smiley svg from svgrepo.com by AUTHOR brankic1979 as fallback -->

--- a/libs/frontend/src/lib/utils/fetch-supported-languages.ts
+++ b/libs/frontend/src/lib/utils/fetch-supported-languages.ts
@@ -7,5 +7,5 @@ export async function fetchSupportedLanguages() {
 	});
 
 	const { languages }: { languages: PuzzleLanguage[] } = await response.json();
-	return languages;
+	return languages.sort();
 }


### PR DESCRIPTION
# Description

Before, it was almost unnoticable if something happened, and you were able to send requests while the previous ones were on-going which could result in a broken page.

I solved it by adding a tiny sleep in there, for the human feedback, and uhmn, a boolean that disables the buttons, when the requests haven't been resolved yet.

Also sorted the languages alphabetically

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
<!-- hard to understand area's should hardly ever exist, if they do it warrants at least an explanation in the description of the PR -->
- [x] I have made corresponding changes to the documentation
