### PR TITLE
fix: zod issue related to next page on puzzles

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,6 +13,5 @@
 
 - [ ] My code follows the style guidelines of this project
 - [ ] I have performed a self-review of my code
-- [ ] I have commented my code, particularly in hard-to-understand areas
-<!-- hard to understand area's should hardly ever exist, if they do it warrants at least an explanation in the description of the PR -->
+- [ ] I have commented my code, particularly in hard-to-understand areas <!-- hard to understand area's should hardly ever exist, if they do it warrants at least an explanation in the description of the PR -->
 - [ ] I have made corresponding changes to the documentation

--- a/libs/frontend/src/lib/components/nav/pagination.svelte
+++ b/libs/frontend/src/lib/components/nav/pagination.svelte
@@ -1,55 +1,49 @@
 <script lang="ts">
+	import { page } from "$app/stores";
 	import { DEFAULT_PAGE } from "types";
+	import { Button } from "../ui/button";
 
 	export let currentPage: number;
 	export let totalPages: number;
 
-	const changePage = (page: number) => {
-		const url = new URL(window.location.href);
-		url.searchParams.set("page", page.toString());
-		window.location.href = url.toString();
-	};
+	function createPaginatedUrl(newPage: number) {
+		let params = new URLSearchParams($page.url.searchParams.toString());
+		params.set("page", newPage.toString());
 
-	const nextPage = () => {
-		changePage(currentPage + 1);
-	};
-
-	const previousPage = () => {
-		changePage(currentPage - 1);
-	};
-
-	const firstPage = () => {
-		changePage(DEFAULT_PAGE);
-	};
-	const lastPage = () => {
-		changePage(totalPages);
-	};
+		return `?${params.toString()}`;
+	}
 </script>
 
 {#if totalPages > DEFAULT_PAGE}
-	<nav class="pagination">
-		<button on:click={firstPage} disabled={currentPage === DEFAULT_PAGE}>First</button>
-		{#if currentPage > DEFAULT_PAGE}
-			<button on:click={previousPage}>Previous</button>
-		{/if}
+	<nav class="flex w-full flex-col items-center justify-center gap-2 md:flex-row md:gap-8">
+		<div class="flex flex-1 justify-end gap-2">
+			{#if currentPage === DEFAULT_PAGE}
+				<Button disabled aria-hidden="true">First</Button>
+			{:else}
+				<Button href={createPaginatedUrl(DEFAULT_PAGE)}>First</Button>
+			{/if}
 
-		<span>Page {currentPage} of {totalPages}</span>
+			{#if currentPage > DEFAULT_PAGE}
+				<Button href={createPaginatedUrl(currentPage - 1)}>Previous</Button>
+			{:else}
+				<Button disabled aria-hidden="true">Previous</Button>
+			{/if}
+		</div>
 
-		{#if currentPage < totalPages}
-			<button on:click={nextPage}>Next</button>
-		{/if}
-		<button on:click={lastPage} disabled={currentPage === totalPages}>Last</button>
+		<p aria-live="polite" role="status">Page {currentPage} of {totalPages}</p>
+
+		<div class="flex flex-1 gap-2">
+			{#if currentPage < totalPages}
+				<Button href={createPaginatedUrl(currentPage + 1)}>Next</Button>
+			{:else}
+				<Button disabled aria-hidden="true">Next</Button>
+			{/if}
+
+			{#if currentPage === totalPages}
+				<Button disabled aria-hidden="true">Last</Button>
+			{:else}
+				<Button href={createPaginatedUrl(totalPages)}>Last</Button>
+			{/if}
+		</div>
 	</nav>
 {/if}
-
-<style>
-	.pagination {
-		display: flex;
-		align-items: center;
-		gap: 1rem;
-	}
-	button:disabled {
-		opacity: 0.5;
-		cursor: not-allowed;
-	}
-</style>

--- a/libs/frontend/src/routes/puzzles/+page.svelte
+++ b/libs/frontend/src/routes/puzzles/+page.svelte
@@ -4,7 +4,7 @@
 	import H1 from "@/components/typography/h1.svelte";
 	import P from "@/components/typography/p.svelte";
 	import Pagination from "@/components/nav/pagination.svelte";
-	import { buildFrontendUrl, frontendUrls } from "types";
+	import { buildFrontendUrl, frontendUrls, type PuzzleDto } from "types";
 	import Button from "@/components/ui/button/button.svelte";
 	import LogicalUnit from "@/components/ui/logical-unit/logical-unit.svelte";
 	import PuzzleDifficultyBadge from "@/features/puzzles/components/puzzle-difficulty-badge.svelte";
@@ -12,11 +12,20 @@
 
 	export let data;
 
-	const { items, page, totalItems, totalPages } = data;
+	let items: PuzzleDto[] = [];
+	let page: number;
+	let totalItems: number;
+	let totalPages: number;
+	$: {
+		items = data.items;
+		page = data.page;
+		totalItems = data.totalItems;
+		totalPages = data.totalPages;
+	}
 </script>
 
 <Container>
-	<LogicalUnit class="flex flex-col md:flex-row md:items-center md:justify-between">
+	<LogicalUnit class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
 		<H1>Puzzles</H1>
 
 		<Button href={frontendUrls.PUZZLE_CREATE}>Create a new puzzle</Button>
@@ -24,7 +33,7 @@
 
 	<!-- TODO: search should come here: -->
 	<!-- <Input placeholder="Search through puzzles" /> -->
-	<LogicalUnit class="flex flex-col gap-4">
+	<LogicalUnit class="flex flex-col gap-8">
 		{#if totalItems <= 0}
 			<P>Couldn't find any puzzles!</P>
 		{:else}
@@ -34,8 +43,6 @@
 
 			<div class="rounded-lg border">
 				<Table.Root>
-					<!-- <Table.Caption class="sr-only">Game submissions leaderboard</Table.Caption> -->
-
 					<Table.Header>
 						<Table.Row>
 							<Table.Head>Title</Table.Head>

--- a/libs/types/src/core/common/schema/paginated-query.schema.ts
+++ b/libs/types/src/core/common/schema/paginated-query.schema.ts
@@ -1,16 +1,8 @@
 import { z } from "zod";
 
-const numericString = z
-	.string()
-	.regex(/^\d+$/, "Must be a numeric string")
-	.transform(Number)
-	.pipe(z.number());
-
-const positiveNumberSchema = z.union([z.number(), numericString]).transform(Number);
-
 export const paginatedQuerySchema = z.object({
-	page: positiveNumberSchema.pipe(z.number().min(1)).default(1),
-	pageSize: positiveNumberSchema.pipe(z.number().min(1).max(100)).default(10)
+	page: z.coerce.number().min(1).default(1),
+	pageSize: z.coerce.number().min(1).max(100).default(10)
 });
 
 export type PaginatedQuery = z.infer<typeof paginatedQuerySchema>;

--- a/libs/types/src/core/common/schema/paginated-query.schema.ts
+++ b/libs/types/src/core/common/schema/paginated-query.schema.ts
@@ -1,7 +1,16 @@
 import { z } from "zod";
 
+const numericString = z
+	.string()
+	.regex(/^\d+$/, "Must be a numeric string")
+	.transform(Number)
+	.pipe(z.number());
+
+const positiveNumberSchema = z.union([z.number(), numericString]).transform(Number);
+
 export const paginatedQuerySchema = z.object({
-	page: z.number().min(1).default(1),
-	pageSize: z.number().min(1).max(100).default(10)
+	page: positiveNumberSchema.pipe(z.number().min(1)).default(1),
+	pageSize: positiveNumberSchema.pipe(z.number().min(1).max(100)).default(10)
 });
+
 export type PaginatedQuery = z.infer<typeof paginatedQuerySchema>;


### PR DESCRIPTION

# Description

the query variables page and pageSize were send over the wire as strings, while the zod schema expected numbers, i made it so now it accepts also strings which represent numbers

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
