### PR TITLE
Make chat scroll on new messages

### DIFF
--- a/libs/frontend/src/lib/features/chat/components/chat-message.svelte
+++ b/libs/frontend/src/lib/features/chat/components/chat-message.svelte
@@ -11,9 +11,16 @@
 	if ($authenticatedUserInfo) {
 		highlight = chatMessage.message.includes("@" + $authenticatedUserInfo.username);
 	}
+
+	function scrollIntoView(element: HTMLElement) {
+		element.scrollIntoView({ block: "nearest" });
+	}
 </script>
 
-<li class={cn("chat-message w-full rounded-lg px-2 py-1", highlight && "highlight")}>
+<li
+	class={cn("chat-message w-full rounded-lg px-2 py-1", highlight && "highlight")}
+	use:scrollIntoView
+>
 	<dl>
 		<dt class="sr-only">Time send</dt>
 		<dd class="mr-1 inline opacity-60">


### PR DESCRIPTION
I think ideally the chat would not scroll if the mouse pointer is currently over the chat, but that can be implemented later when we fix the chat component to make more sense.

closes #66