### PR TITLE
fix: navigation items don't take full width

### DIFF
--- a/libs/frontend/src/lib/components/nav/user-dropdown.svelte
+++ b/libs/frontend/src/lib/components/nav/user-dropdown.svelte
@@ -40,16 +40,14 @@
 	<DropdownMenu.Content>
 		<DropdownMenu.Group>
 			{#each dropdownLinksLoggedIn as { text, href }}
-				<DropdownMenu.Item>
-					<a class="h-full w-full" {href}>{text}</a>
+				<DropdownMenu.Item {href}>
+					{text}
 				</DropdownMenu.Item>
 			{/each}
 
 			<DropdownMenu.Separator></DropdownMenu.Separator>
 
-			<DropdownMenu.Item>
-				<a class="h-full w-full" href="/logout"> Log out </a>
-			</DropdownMenu.Item>
+			<DropdownMenu.Item href={frontendUrls.LOGOUT}>Log out</DropdownMenu.Item>
 		</DropdownMenu.Group>
 	</DropdownMenu.Content>
 </DropdownMenu.Root>


### PR DESCRIPTION
# Description

fix: navigation items don't take full width, now they do, previously the href wasn't added on the menu item, but rather a link within a menuitem, however, the menu item has default styling, causing the issue

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas <!-- hard to understand area's should hardly ever exist, if they do it warrants at least an explanation in the description of the PR -->
- [x] I have made corresponding changes to the documentation
