### PR TITLE
use FRONTEND_HOST environment variable for cookie domain

### DIFF
--- a/libs/backend/src/routes/login/index.ts
+++ b/libs/backend/src/routes/login/index.ts
@@ -42,7 +42,7 @@ export default async function loginRoutes(fastify: FastifyInstance) {
 					httpOnly: true,
 					secure: process.env.NODE_ENV === "production",
 					sameSite: process.env.NODE_ENV === "production" ? "none" : "lax",
-					domain: process.env.NODE_ENV === "production" ? ".codincod.com" : "localhost",
+					domain: process.env.FRONTEND_HOST ?? "localhost",
 					maxAge: 3600
 				})
 				.send({ message: "Login successful" });

--- a/libs/backend/src/routes/register/index.ts
+++ b/libs/backend/src/routes/register/index.ts
@@ -54,7 +54,7 @@ export default async function registerRoutes(fastify: FastifyInstance) {
 					httpOnly: true,
 					secure: process.env.NODE_ENV === "production",
 					sameSite: process.env.NODE_ENV === "production" ? "none" : "lax",
-					domain: process.env.NODE_ENV === "production" ? ".codincod.com" : "localhost",
+					domain: process.env.FRONTEND_HOST ?? "localhost",
 					maxAge: 3600
 				})
 				.send({ message: "User registered successfully" });

--- a/libs/frontend/src/lib/features/authentication/utils/logout.ts
+++ b/libs/frontend/src/lib/features/authentication/utils/logout.ts
@@ -6,7 +6,7 @@ export function logout(cookies: Cookies) {
 	const isProduction = env.NODE_ENV === "production";
 
 	cookies.delete(cookieKeys.TOKEN, {
-		domain: isProduction ? ".codincod.com" : "localhost",
+		domain: env.FRONTEND_HOST ?? "localhost",
 		path: frontendUrls.ROOT,
 		sameSite: isProduction ? "none" : "lax",
 		secure: isProduction

--- a/libs/frontend/src/lib/features/authentication/utils/set-cookie.ts
+++ b/libs/frontend/src/lib/features/authentication/utils/set-cookie.ts
@@ -15,7 +15,7 @@ export function setCookie(result: Response, cookies: Cookies) {
 
 		// Set the cookie using SvelteKit's cookies API
 		cookies.set(name, value, {
-			domain: isProduction ? ".codincod.com" : "localhost",
+			domain: env.FRONTEND_HOST ?? "localhost",
 			httpOnly: true,
 			path: frontendUrls.ROOT,
 			sameSite: isProduction ? "none" : "lax",

--- a/libs/frontend/src/routes/logout/+page.server.ts
+++ b/libs/frontend/src/routes/logout/+page.server.ts
@@ -6,7 +6,7 @@ export const load = async ({ cookies }: PageServerLoadEvent) => {
 	const isProduction = env.NODE_ENV === "production";
 
 	cookies.delete(cookieKeys.TOKEN, {
-		domain: isProduction ? ".codincod.com" : "localhost",
+		domain: env.FRONTEND_HOST ?? "localhost",
 		path: frontendUrls.ROOT,
 		sameSite: isProduction ? "none" : "lax",
 		secure: isProduction


### PR DESCRIPTION
I hope this doesn't break production configuration but this fixes an issue where running codincod locally wouldn't work unless using "localhost" as the host (eg. 127.0.0.1 or a custom codincod.local domain would not work)