### PR TITLE
fix: logged out user can't see add comment form anymore

### DIFF
--- a/libs/frontend/src/lib/features/comment/components/comment.svelte
+++ b/libs/frontend/src/lib/features/comment/components/comment.svelte
@@ -15,6 +15,7 @@
 	import { CircleArrowDown, CircleArrowUp, MessageCircle, MessageCircleOff } from "lucide-svelte";
 	import { fetchWithAuthenticationCookie } from "@/features/authentication/utils/fetch-with-authentication-cookie";
 	import { apiUrls, buildApiUrl } from "@/config/api";
+	import { isAuthenticated } from "@/stores";
 
 	export let comment: CommentDto;
 
@@ -113,7 +114,7 @@
 		</Button>
 	</LogicalUnit>
 
-	{#if isReplying}
+	{#if isReplying && $isAuthenticated}
 		<AddCommentForm
 			replyOnId={comment._id}
 			commentType={commentTypeEnum.COMMENT}

--- a/libs/frontend/src/routes/puzzles/[id]/+page.svelte
+++ b/libs/frontend/src/routes/puzzles/[id]/+page.svelte
@@ -93,9 +93,15 @@
 
 		<H2 class="mt-8">Comments</H2>
 
-		<AddCommentForm commentType={commentTypeEnum.PUZZLE} replyOnId={puzzleId} {onCommentAdded} />
+		{#if $isAuthenticated}
+			<AddCommentForm commentType={commentTypeEnum.PUZZLE} replyOnId={puzzleId} {onCommentAdded} />
+		{/if}
 
-		<Comments comments={puzzleComments} />
+		{#if puzzleComments.length > 0}
+			<Comments comments={puzzleComments} />
+		{:else}
+			<p class="text-stone-400 dark:text-stone-600">No one commented yet.</p>
+		{/if}
 	</LogicalUnit>
 </Container>
 


### PR DESCRIPTION
# Description

Logged out user was able to see a textarea, but couldn't do anything with it, bad design, so hid it when the users are logged out.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas <!-- hard to understand area's should hardly ever exist, if they do it warrants at least an explanation in the description of the PR -->
- [x] I have made corresponding changes to the documentation
