### PR TITLE
fix: add codemirror-wrapper class to monospaced items

### DIFF
--- a/libs/frontend/src/app.css
+++ b/libs/frontend/src/app.css
@@ -120,6 +120,7 @@ a:focus {
 code,
 pre,
 .monospaced,
-.font-mono {
+.font-mono,
+.codemirror-wrapper {
 	font-family: "Inconsolata", monospace;
 }


### PR DESCRIPTION
# Description

Due to a previous change, where i set all of the fonts to the same one, there was an issue related to a codemirror editor instance having the wrong font, this update ensures the font in the codemirror editor is a monospaced font

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas <!-- hard to understand area's should hardly ever exist, if they do it warrants at least an explanation in the description of the PR -->
- [x] I have made corresponding changes to the documentation
