### PR TITLE
fix: align text vertical center in standingstable

### DIFF
--- a/libs/frontend/src/lib/features/game/standings/components/standings-table.svelte
+++ b/libs/frontend/src/lib/features/game/standings/components/standings-table.svelte
@@ -71,22 +71,26 @@
 						<Table.Cell><UserHoverCard username={user.username} /></Table.Cell>
 						<Table.Cell>{language}</Table.Cell>
 						<Table.Cell>
-							{#if result.successRate === 1}
-								<FishIcon
-									aria-hidden="true"
-									class={cn("icon mr-1", calculatePuzzleResultIconColor(result.result))}
-								/>
-							{:else}
-								<FishOffIcon
-									aria-hidden="true"
-									class={cn("icon mr-1", calculatePuzzleResultIconColor(result.result))}
-								/>
-							{/if}{Math.round(result.successRate * 100)}%
+							<span class="flex items-center">
+								{#if result.successRate === 1}
+									<FishIcon
+										aria-hidden="true"
+										class={cn("icon mr-1", calculatePuzzleResultIconColor(result.result))}
+									/>
+								{:else}
+									<FishOffIcon
+										aria-hidden="true"
+										class={cn("icon mr-1", calculatePuzzleResultIconColor(result.result))}
+									/>
+								{/if}{Math.round(result.successRate * 100)}%
+							</span>
 						</Table.Cell>
 						<Table.Cell>
-							<!-- todo: make this more readable for screen readers somehow -->
-							<Hourglass aria-hidden="true" class="icon default mr-1" />
-							{formatDuration(createdAt)}
+							<span class="flex items-center">
+								<!-- todo: make this more readable for screen readers somehow -->
+								<Hourglass aria-hidden="true" class="icon default mr-1" />
+								{formatDuration(createdAt)}
+							</span>
 						</Table.Cell>
 						<Table.Cell>
 							<Button


### PR DESCRIPTION
# Description

Text wasn't vertically centered in standings table, it now is

fixes: https://github.com/JuiceMitApfelnDrin/CodinCod/issues/147

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas <!-- hard to understand area's should hardly ever exist, if they do it warrants at least an explanation in the description of the PR -->
- [x] I have made corresponding changes to the documentation
